### PR TITLE
Patched external tileset functionality when parsing tilesets. Only works...

### DIFF
--- a/src/TmxMap.cpp
+++ b/src/TmxMap.cpp
@@ -113,9 +113,9 @@ namespace Tmx
 
     void Map::ParseFile(const string &fileName) 
     {
-        file_name = fileName;
+		file_name = fileName;
 
-        int lastSlash = fileName.find_last_of("/");
+		int lastSlash = fileName.find_last_of("/");
 
         // Get the directory of the file using substring.
         if (lastSlash > 0) 
@@ -131,7 +131,7 @@ namespace Tmx
         int fileSize;
 
         // Open the file for reading.
-        FILE *file = fopen(fileName.c_str(), "rb");
+		FILE *file = fopen(fileName.c_str(), "rb");
 
         // Check if the file could not be opened.
         if (!file) 
@@ -227,7 +227,7 @@ namespace Tmx
             {
                 // Allocate a new tileset and parse it.
                 Tileset *tileset = new Tileset();
-                tileset->Parse(node->ToElement());
+                tileset->Parse(this, node->ToElement());
 
                 // Add the tileset to the list.
                 tilesets.push_back(tileset);

--- a/src/TmxTileset.cpp
+++ b/src/TmxTileset.cpp
@@ -30,6 +30,7 @@
 #include "TmxTileset.h"
 #include "TmxImage.h"
 #include "TmxTile.h"
+#include "TmxMap.h"
 
 using std::vector;
 using std::string;
@@ -71,44 +72,37 @@ namespace Tmx
         }
     }
 
-    void Tileset::Parse(const TiXmlNode *tilesetNode) 
+    void Tileset::Parse(Tmx::Map* map, const TiXmlNode *tilesetNode) 
     {
-        const TiXmlElement *tilesetElem = tilesetNode->ToElement();
+		const TiXmlElement *tilesetElem = tilesetNode->ToElement();
 
         // Read all the attributes into local variables.
-        tilesetElem->Attribute("firstgid", &first_gid);
-		
+		tilesetElem->Attribute("firstgid", &first_gid);
+
 		// Read a source attribute if we have one
 		const char* source = tilesetElem->Attribute("source");
-		
-		// may be unnecessary - but create new pointers that we need to assign to the new document
 		TiXmlNode *newNode;
 		TiXmlElement* newElem;
 		TiXmlDocument newDoc;
-		
-		// If there's a source attribute then we need to redirect tilesetNode and tilesetElem to point to the new xml file
 		if (source)
 		{
 			std::string szSource(source);
-			szSource = "../maps/" + szSource;
+			szSource = map->GetFilepath() + szSource;
 			// Check if the file could not be opened.
 			if (newDoc.LoadFile(szSource.c_str()))
 			{
 				newDoc.Parse(szSource.c_str());
-				
-				// File loaded with no issues
 				if (!newDoc.Error())
 				{
 					newNode = newDoc.FirstChild("tileset");
 					newElem = newNode->ToElement();
 
-					// assign to the new node/element in the new xml file
 					tilesetNode = newNode;
 					tilesetElem = newElem;
 				}
 			}
 		}
-		
+
         tilesetElem->Attribute("tilewidth", &tile_width);
         tilesetElem->Attribute("tileheight", &tile_height);
         tilesetElem->Attribute("margin", &margin);
@@ -117,7 +111,7 @@ namespace Tmx
         name = tilesetElem->Attribute("name");
 
         // Parse the image.
-        const TiXmlNode *imageNode = tilesetNode->FirstChild("image");
+		const TiXmlNode *imageNode = tilesetNode->FirstChild("image");
         
         if (imageNode) 
         {
@@ -138,7 +132,7 @@ namespace Tmx
 
 
         // Iterate through all of the tile elements and parse each.
-        const TiXmlNode *tileNode = tilesetNode->FirstChild("tile");
+		const TiXmlNode *tileNode = tilesetNode->FirstChild("tile");
         while (tileNode)
         {
             // Parse it to get the tile id.
@@ -153,7 +147,7 @@ namespace Tmx
 
         
         // Parse the properties if any.
-        const TiXmlNode *propertiesNode = tilesetNode->FirstChild("properties");
+		const TiXmlNode *propertiesNode = tilesetNode->FirstChild("properties");
         
         if (propertiesNode) 
         {

--- a/src/TmxTileset.cpp
+++ b/src/TmxTileset.cpp
@@ -77,6 +77,38 @@ namespace Tmx
 
         // Read all the attributes into local variables.
         tilesetElem->Attribute("firstgid", &first_gid);
+		
+		// Read a source attribute if we have one
+		const char* source = tilesetElem->Attribute("source");
+		
+		// may be unnecessary - but create new pointers that we need to assign to the new document
+		TiXmlNode *newNode;
+		TiXmlElement* newElem;
+		TiXmlDocument newDoc;
+		
+		// If there's a source attribute then we need to redirect tilesetNode and tilesetElem to point to the new xml file
+		if (source)
+		{
+			std::string szSource(source);
+			szSource = "../maps/" + szSource;
+			// Check if the file could not be opened.
+			if (newDoc.LoadFile(szSource.c_str()))
+			{
+				newDoc.Parse(szSource.c_str());
+				
+				// File loaded with no issues
+				if (!newDoc.Error())
+				{
+					newNode = newDoc.FirstChild("tileset");
+					newElem = newNode->ToElement();
+
+					// assign to the new node/element in the new xml file
+					tilesetNode = newNode;
+					tilesetElem = newElem;
+				}
+			}
+		}
+		
         tilesetElem->Attribute("tilewidth", &tile_width);
         tilesetElem->Attribute("tileheight", &tile_height);
         tilesetElem->Attribute("margin", &margin);

--- a/src/TmxTileset.h
+++ b/src/TmxTileset.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "TmxPropertySet.h"
+#include "TmxMap.h"
 
 class TiXmlNode;
 
@@ -51,7 +52,7 @@ namespace Tmx
         ~Tileset();
 
         // Parse a tileset element.
-        void Parse(const TiXmlNode *tilesetNode);
+        void Parse(Tmx::Map* map, const TiXmlNode *tilesetNode);
 
         // Returns the global id of the first tile.
         int GetFirstGid() const { return first_gid; }
@@ -88,7 +89,7 @@ namespace Tmx
         int first_gid;
         
         std::string name;
-        
+
         int tile_width;
         int tile_height;
         int margin;


### PR DESCRIPTION
... right now if the .tmx file is in ../maps relative to the program .exe. The map directory should be sent into the parser and be available to any of the parse() functions.