### PR TITLE
Fix formatting and incorrect method name in TmxTile.h, TmxTile.cpp, test

### DIFF
--- a/src/TmxTile.cpp
+++ b/src/TmxTile.cpp
@@ -31,14 +31,18 @@
 
 namespace Tmx
 {
-    Tile::Tile() : id(0), properties(), isAnimated(false), totalDuration(0)
-    {}
-    Tile::Tile(int id) : id(id), properties(), isAnimated(false), totalDuration(0)
-    {}
-
+    Tile::Tile() :
+            id(0), properties(), isAnimated(false), totalDuration(0)
+    {
+    }
+    Tile::Tile(int id) :
+            id(id), properties(), isAnimated(false), totalDuration(0)
+    {
+    }
 
     Tile::~Tile()
-    {}
+    {
+    }
 
     void Tile::Parse(const tinyxml2::XMLNode *tileNode)
     {
@@ -48,7 +52,8 @@ namespace Tmx
         id = tileElem->IntAttribute("id");
 
         // Parse the properties if any.
-        const tinyxml2::XMLNode *propertiesNode = tileNode->FirstChildElement("properties");
+        const tinyxml2::XMLNode *propertiesNode = tileNode->FirstChildElement(
+                "properties");
 
         if (propertiesNode)
         {
@@ -56,28 +61,33 @@ namespace Tmx
         }
 
         // Parse the animation if there is one.
-        const tinyxml2::XMLNode *animationNode = tileNode->FirstChildElement("animation");
+        const tinyxml2::XMLNode *animationNode = tileNode->FirstChildElement(
+                "animation");
 
-        if(animationNode)
+        if (animationNode)
         {
-        	isAnimated = true;
+            isAnimated = true;
 
-        	const tinyxml2::XMLNode *frameNode = animationNode->FirstChildElement("frame");
-        	unsigned int durationSum = 0;
+            const tinyxml2::XMLNode *frameNode =
+                    animationNode->FirstChildElement("frame");
+            unsigned int durationSum = 0;
 
-        	while(frameNode != NULL) {
-        		const tinyxml2::XMLElement *frameElement = frameNode->ToElement();
+            while (frameNode != NULL)
+            {
+                const tinyxml2::XMLElement *frameElement =
+                        frameNode->ToElement();
 
-        		const int tileID = frameElement->IntAttribute("tileid");
-        		const unsigned int duration = frameElement->IntAttribute("duration");
+                const int tileID = frameElement->IntAttribute("tileid");
+                const unsigned int duration = frameElement->IntAttribute(
+                        "duration");
 
-        		frames.push_back(AnimationFrame(tileID, duration));
-        		durationSum += duration;
+                frames.push_back(AnimationFrame(tileID, duration));
+                durationSum += duration;
 
-        		frameNode = frameNode->NextSiblingElement("frame");
-        	}
+                frameNode = frameNode->NextSiblingElement("frame");
+            }
 
-        	totalDuration = durationSum;
+            totalDuration = durationSum;
         }
     }
 }

--- a/src/TmxTile.h
+++ b/src/TmxTile.h
@@ -27,13 +27,14 @@
 
 #include "TmxPropertySet.h"
 
-namespace tinyxml2 {
+namespace tinyxml2
+{
     class XMLNode;
 }
 
 namespace Tmx
 {
-	class AnimationFrame;
+    class AnimationFrame;
 
     //-------------------------------------------------------------------------
     // Class to contain information about every tile in the tileset/tiles
@@ -53,23 +54,41 @@ namespace Tmx
         void Parse(const tinyxml2::XMLNode *tileNode);
 
         // Get the Id. (relative to the tileset)
-        int GetId() const { return id; }
+        int GetId() const
+        {
+            return id;
+        }
 
         // Returns true if the tile is animated (has one or more animation frames)
-        bool IsAnimated() const { return isAnimated; }
+        bool IsAnimated() const
+        {
+            return isAnimated;
+        }
 
         // Returns the number of frames of the animation. If the tile is not animated, returns 0.
-        int GetFrameCount() const { return frames.size(); }
+        int GetFrameCount() const
+        {
+            return frames.size();
+        }
 
         // Returns the total duration of the animation, in milliseconds,
         // or 0 if the tile is not animated.
-        unsigned int GetTotalDuration() const { return totalDuration; }
+        unsigned int GetTotalDuration() const
+        {
+            return totalDuration;
+        }
 
         // Returns the frames of the animation.
-        const std::vector<AnimationFrame> &getFrames() const { return frames; }
+        const std::vector<AnimationFrame> &GetFrames() const
+        {
+            return frames;
+        }
 
         // Get a set of properties regarding the tile.
-        const Tmx::PropertySet &GetProperties() const { return properties; }
+        const Tmx::PropertySet &GetProperties() const
+        {
+            return properties;
+        }
 
     private:
         int id;
@@ -82,32 +101,39 @@ namespace Tmx
     };
 
     //-------------------------------------------------------------------------
-	// Class containing information about an animated tile. This includes the
+    // Class containing information about an animated tile. This includes the
     // duration of each frame and the various ids of each frame in the
     // animation.
-	//-------------------------------------------------------------------------
+    //-------------------------------------------------------------------------
     class AnimationFrame
-    	{
-    	public:
-    		// This constructor shouldn't be used, ideally.
-    		AnimationFrame() : tileID(-1), duration(0) {}
+    {
+    public:
+        // This constructor shouldn't be used, ideally.
+        AnimationFrame() :
+                tileID(-1), duration(0)
+        {
+        }
 
-    		// Create a new animation frame with a specified tile id and duration.
-    		AnimationFrame(int tileID, unsigned int duration)
-    			: tileID(tileID), duration(duration) {}
+        // Create a new animation frame with a specified tile id and duration.
+        AnimationFrame(int tileID, unsigned int duration) :
+                tileID(tileID), duration(duration)
+        {
+        }
 
-    		// Get the tile id of this frame, relative to the containing tileset.
-    		int GetTileID() const {
-    			return tileID;
-    		}
+        // Get the tile id of this frame, relative to the containing tileset.
+        int GetTileID() const
+        {
+            return tileID;
+        }
 
-    		// Get the duration of this frame in milliseconds.
-    		unsigned int GetDuration() const {
-    			return duration;
-    		}
+        // Get the duration of this frame in milliseconds.
+        unsigned int GetDuration() const
+        {
+            return duration;
+        }
 
-    	private:
-    		int tileID;
-    		unsigned int duration;
-    	};
+    private:
+        int tileID;
+        unsigned int duration;
+    };
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -25,145 +25,181 @@
 #include <cstdio>
 #include <stdlib.h>
 
-int main() {
-	Tmx::Map *map = new Tmx::Map();
-	map->ParseFile("./example/example.tmx");
+int main()
+{
+    Tmx::Map *map = new Tmx::Map();
+    map->ParseFile("./example/example.tmx");
 
-	if (map->HasError()) {
-		printf("error code: %d\n", map->GetErrorCode());
-		printf("error text: %s\n", map->GetErrorText().c_str());
+    if (map->HasError())
+    {
+        printf("error code: %d\n", map->GetErrorCode());
+        printf("error text: %s\n", map->GetErrorText().c_str());
 
-		system("PAUSE");
+        system("PAUSE");
 
-		return map->GetErrorCode();
-	}
+        return map->GetErrorCode();
+    }
 
-	// Iterate through the tilesets.
-	for (int i = 0; i < map->GetNumTilesets(); ++i) {
-		printf("                                    \n");
-		printf("====================================\n");
-		printf("Tileset : %02d\n", i);
-		printf("====================================\n");
+    // Iterate through the tilesets.
+    for (int i = 0; i < map->GetNumTilesets(); ++i)
+    {
+        printf("                                    \n");
+        printf("====================================\n");
+        printf("Tileset : %02d\n", i);
+        printf("====================================\n");
 
-		// Get a tileset.
-		const Tmx::Tileset *tileset = map->GetTileset(i);
+        // Get a tileset.
+        const Tmx::Tileset *tileset = map->GetTileset(i);
 
-		// Print tileset information.
-		printf("Name: %s\n", tileset->GetName().c_str());
-		printf("Margin: %d\n", tileset->GetMargin());
-		printf("Spacing: %d\n", tileset->GetSpacing());
-		printf("Image Width: %d\n", tileset->GetImage()->GetWidth());
-		printf("Image Height: %d\n", tileset->GetImage()->GetHeight());
-		printf("Image Source: %s\n", tileset->GetImage()->GetSource().c_str());
-		printf("Transparent Color (hex): %s\n", tileset->GetImage()->GetTransparentColor().c_str());
+        // Print tileset information.
+        printf("Name: %s\n", tileset->GetName().c_str());
+        printf("Margin: %d\n", tileset->GetMargin());
+        printf("Spacing: %d\n", tileset->GetSpacing());
+        printf("Image Width: %d\n", tileset->GetImage()->GetWidth());
+        printf("Image Height: %d\n", tileset->GetImage()->GetHeight());
+        printf("Image Source: %s\n", tileset->GetImage()->GetSource().c_str());
+        printf("Transparent Color (hex): %s\n",
+                tileset->GetImage()->GetTransparentColor().c_str());
 
-		if (tileset->GetTiles().size() > 0) {
-			// Get a tile from the tileset.
-			const Tmx::Tile *tile = *(tileset->GetTiles().begin());
+        if (tileset->GetTiles().size() > 0)
+        {
+            // Get a tile from the tileset.
+            const Tmx::Tile *tile = *(tileset->GetTiles().begin());
 
-			// Print the properties of a tile.
-			std::map< std::string, std::string > list = tile->GetProperties().GetList();
-			std::map< std::string, std::string >::iterator iter;
-			for (iter = list.begin(); iter != list.end(); ++iter) {
-				printf("%s = %s\n", iter->first.c_str(), iter->second.c_str());
-			}
+            // Print the properties of a tile.
+            std::map<std::string, std::string> list =
+                    tile->GetProperties().GetList();
+            std::map<std::string, std::string>::iterator iter;
+            for (iter = list.begin(); iter != list.end(); ++iter)
+            {
+                printf("%s = %s\n", iter->first.c_str(), iter->second.c_str());
+            }
 
-			if(tile->IsAnimated()) {
-				printf("Tile is animated: %d frames with total duration of %dms.\n", tile->GetFrameCount(), tile->GetTotalDuration());
+            if (tile->IsAnimated())
+            {
+                printf(
+                        "Tile is animated: %d frames with total duration of %dms.\n",
+                        tile->GetFrameCount(), tile->GetTotalDuration());
 
-				const std::vector<Tmx::AnimationFrame> &frames = tile->getFrames();
+                const std::vector<Tmx::AnimationFrame> &frames =
+                        tile->GetFrames();
 
-				int i = 0;
-				for(std::vector<Tmx::AnimationFrame>::const_iterator it = frames.begin(); it != frames.end(); it++, i++) {
-					printf("\tFrame %d: Tile ID = %d, Duration = %dms\n", i, it->GetTileID(), it->GetDuration());
-				}
-			}
-		}
-	}
+                int i = 0;
+                for (std::vector<Tmx::AnimationFrame>::const_iterator it =
+                        frames.begin(); it != frames.end(); it++, i++)
+                {
+                    printf("\tFrame %d: Tile ID = %d, Duration = %dms\n", i,
+                            it->GetTileID(), it->GetDuration());
+                }
+            }
+        }
+    }
 
-	// Iterate through the layers.
-	for (int i = 0; i < map->GetNumLayers(); ++i) {
-		printf("                                    \n");
-		printf("====================================\n");
-		printf("Layer : %02d/%s \n", i, map->GetLayer(i)->GetName().c_str());
-		printf("====================================\n");
+    // Iterate through the layers.
+    for (int i = 0; i < map->GetNumLayers(); ++i)
+    {
+        printf("                                    \n");
+        printf("====================================\n");
+        printf("Layer : %02d/%s \n", i, map->GetLayer(i)->GetName().c_str());
+        printf("====================================\n");
 
-		// Get a layer.
-		const Tmx::Layer *layer = map->GetLayer(i);
+        // Get a layer.
+        const Tmx::Layer *layer = map->GetLayer(i);
 
-		for (int y = 0; y < layer->GetHeight(); ++y) {
-			for (int x = 0; x < layer->GetWidth(); ++x) {
-				// Get the tile's id.
-				printf("%03d", layer->GetTileId(x, y));
+        for (int y = 0; y < layer->GetHeight(); ++y)
+        {
+            for (int x = 0; x < layer->GetWidth(); ++x)
+            {
+                // Get the tile's id.
+                printf("%03d", layer->GetTileId(x, y));
 
-				// Find a tileset for that id.
-				//const Tmx::Tileset *tileset = map->FindTileset(layer->GetTileId(x, y));
-				if (layer->IsTileFlippedHorizontally(x, y)){
-					printf("h");
-				}else{
-					printf(" ");
-				}
-				if (layer->IsTileFlippedVertically(x, y)){
-					printf("v");
-				}else{
-					printf(" ");
-				}
-				if (layer->IsTileFlippedDiagonally(x, y)){
-					printf("d ");
-				} else {
-					printf("  ");
-				}
-			}
+                // Find a tileset for that id.
+                //const Tmx::Tileset *tileset = map->FindTileset(layer->GetTileId(x, y));
+                if (layer->IsTileFlippedHorizontally(x, y))
+                {
+                    printf("h");
+                }
+                else
+                {
+                    printf(" ");
+                }
+                if (layer->IsTileFlippedVertically(x, y))
+                {
+                    printf("v");
+                }
+                else
+                {
+                    printf(" ");
+                }
+                if (layer->IsTileFlippedDiagonally(x, y))
+                {
+                    printf("d ");
+                }
+                else
+                {
+                    printf("  ");
+                }
+            }
 
-			printf("\n");
-		}
-	}
+            printf("\n");
+        }
+    }
 
-	printf("\n\n");
+    printf("\n\n");
 
-	// Iterate through all of the object groups.
-	for (int i = 0; i < map->GetNumObjectGroups(); ++i) {
-		printf("                                    \n");
-		printf("====================================\n");
-		printf("Object group : %02d\n", i);
-		printf("====================================\n");
+    // Iterate through all of the object groups.
+    for (int i = 0; i < map->GetNumObjectGroups(); ++i)
+    {
+        printf("                                    \n");
+        printf("====================================\n");
+        printf("Object group : %02d\n", i);
+        printf("====================================\n");
 
-		// Get an object group.
-		const Tmx::ObjectGroup *objectGroup = map->GetObjectGroup(i);
+        // Get an object group.
+        const Tmx::ObjectGroup *objectGroup = map->GetObjectGroup(i);
 
-		// Iterate through all objects in the object group.
-		for (int j = 0; j < objectGroup->GetNumObjects(); ++j) {
-			// Get an object.
-			const Tmx::Object *object = objectGroup->GetObject(j);
+        // Iterate through all objects in the object group.
+        for (int j = 0; j < objectGroup->GetNumObjects(); ++j)
+        {
+            // Get an object.
+            const Tmx::Object *object = objectGroup->GetObject(j);
 
-			// Print information about the object.
-			printf("Object Name: %s\n", object->GetName().c_str());
-			printf("Object Position: (%03d, %03d)\n", object->GetX(), object->GetY());
-			printf("Object Size: (%03d, %03d)\n", object->GetWidth(), object->GetHeight());
+            // Print information about the object.
+            printf("Object Name: %s\n", object->GetName().c_str());
+            printf("Object Position: (%03d, %03d)\n", object->GetX(),
+                    object->GetY());
+            printf("Object Size: (%03d, %03d)\n", object->GetWidth(),
+                    object->GetHeight());
 
-			// Print Polygon points.
-			const Tmx::Polygon *polygon = object->GetPolygon();
-			if (polygon != 0) {
-				for (int i = 0; i < polygon->GetNumPoints(); i++) {
-					const Tmx::Point &point = polygon->GetPoint(i);
-					printf("Object Polygon: Point %d: (%d, %d)\n", i, point.x, point.y);
-				}
-			}
+            // Print Polygon points.
+            const Tmx::Polygon *polygon = object->GetPolygon();
+            if (polygon != 0)
+            {
+                for (int i = 0; i < polygon->GetNumPoints(); i++)
+                {
+                    const Tmx::Point &point = polygon->GetPoint(i);
+                    printf("Object Polygon: Point %d: (%d, %d)\n", i, point.x,
+                            point.y);
+                }
+            }
 
-			// Print Polyline points.
-			const Tmx::Polyline *polyline = object->GetPolyline();
-			if (polyline != 0) {
-				for (int i = 0; i < polyline->GetNumPoints(); i++) {
-					const Tmx::Point &point = polyline->GetPoint(i);
-					printf("Object Polyline: Point %d: (%d, %d)\n", i, point.x, point.y);
-				}
-			}
-		}
-	}
+            // Print Polyline points.
+            const Tmx::Polyline *polyline = object->GetPolyline();
+            if (polyline != 0)
+            {
+                for (int i = 0; i < polyline->GetNumPoints(); i++)
+                {
+                    const Tmx::Point &point = polyline->GetPoint(i);
+                    printf("Object Polyline: Point %d: (%d, %d)\n", i, point.x,
+                            point.y);
+                }
+            }
+        }
+    }
 
-	delete map;
+    delete map;
 
-	system("PAUSE");
+    system("PAUSE");
 
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
Hi.

I noticed I named a method inconsistently with the rest of the functions in the library, and my commits used tabs instead of spaces. test.cpp was inconsistent in this regard too. I've changed my stuff to be all spaces, changed the method "getFrames" to "GetFrames" in Tmx::Tile, and changed test.cpp to use the new method name and to use spaces as in the rest of the library. Sorry about that!