### PR TITLE
Changes commented on commit b5e6040

### DIFF
--- a/src/TmxMapTile.h
+++ b/src/TmxMapTile.h
@@ -59,7 +59,8 @@ namespace Tmx
             , flippedVertically((_gid & FlippedVerticallyFlag) != 0)
             , flippedDiagonally((_gid & FlippedDiagonallyFlag) != 0)
         {
-            //id -= _tilesetFirstGid;
+            gid = id;
+            id -= _tilesetFirstGid;
         }
 
         // Tileset id.
@@ -67,6 +68,9 @@ namespace Tmx
 
         // Id.
         unsigned id;
+
+        // Gid.
+        unsigned gid;
 
         // True when the tile should be drawn flipped horizontally.
         bool flippedHorizontally;

--- a/src/TmxTileLayer.h
+++ b/src/TmxTileLayer.h
@@ -77,8 +77,11 @@ namespace Tmx
         // Parse a tile layer node.
         void Parse(const tinyxml2::XMLNode *tileLayerNode);
 
-        // Pick a specific tile from the list.
+        // Pick a specific tile id from the list.
         unsigned GetTileId(int x, int y) const { return tile_map[y * width + x].id; }
+
+        // Pick a specific tile gid from the list.
+        unsigned GetTileGid(int x, int y) const { return tile_map[y * width + x].gid; }
 
         // Get the tileset index for a tileset from the list.
         int GetTileTilesetIndex(int x, int y) const { return tile_map[y * width + x].tilesetId; }

--- a/test/example/example.tmx
+++ b/test/example/example.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" nextobjectid="4">
  <tileset firstgid="1" name="tmw_desert_spacing" tilewidth="32" tileheight="32" spacing="1" margin="1">
   <image source="tmw_desert_spacing.png" trans="ffffff" width="265" height="199"/>
   <tile id="0">
@@ -51,13 +51,13 @@
   </data>
  </layer>
  <objectgroup name="Polygon Testing">
-  <object x="93" y="49">
+  <object id="1" x="93" y="49">
    <polygon points="0,0 51,6 9,56"/>
   </object>
-  <object x="114" y="176">
+  <object id="2" x="114" y="176">
    <polygon points="0,0 51,-24 60,33"/>
   </object>
-  <object x="228" y="88">
+  <object id="3" x="228" y="88">
    <polyline points="0,0 54,95 -3,183 -131,201"/>
   </object>
  </objectgroup>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -56,6 +56,7 @@ int main(int argc, char * argv[])
         printf("Name: %s\n", tileset->GetName().c_str());
         printf("Margin: %d\n", tileset->GetMargin());
         printf("Spacing: %d\n", tileset->GetSpacing());
+        printf("First gid: %d\n", tileset->GetFirstGid());
         printf("Image Width: %d\n", tileset->GetImage()->GetWidth());
         printf("Image Height: %d\n", tileset->GetImage()->GetHeight());
         printf("Image Source: %s\n", tileset->GetImage()->GetSource().c_str());
@@ -113,12 +114,12 @@ int main(int argc, char * argv[])
             {
                 if (tileLayer->GetTileTilesetIndex(x, y) == -1)
                 {
-                    printf("...    ");
+                    printf("........    ");
                 }
                 else
                 {
-                    // Get the tile's id.
-                    printf("%03d", tileLayer->GetTileId(x, y));
+                    // Get the tile's id and gid.
+                    printf("%03d(%03d)", tileLayer->GetTileId(x, y), tileLayer->GetTileGid(x, y));
                 
                     // Find a tileset for that id.
                     //const Tmx::Tileset *tileset = map->FindTileset(layer->GetTileId(x, y));


### PR DESCRIPTION
[Comments](https://github.com/andrewrk/tmxparser/commit/b5e6040588abb147cb4364e1ddaa5a32c7b6bd1a):
> @georgerbr:
> Consider following [the spec](https://github.com/bjorn/tiled/wiki/TMX-Map-Format), which states id is the local tile ID within its tileset, and gid is the global tile ID.  
> @Galbar:
> OK, I see what you mean.
Then, in my opinion, we should add the gid to MapTile to make it easier to get it. Also, there should also be a getter TileLayer called GetTileGid().
What do you think?  
> @georgerbr:
> Sounds good to me.

Added some lines to the test.cpp to test the changes.