### PR TITLE
Fixed trim bug and added tsx support

### DIFF
--- a/src/TmxMap.cpp
+++ b/src/TmxMap.cpp
@@ -258,7 +258,7 @@ namespace Tmx
             {
                 // Allocate a new tileset and parse it.
                 Tileset *tileset = new Tileset();
-                tileset->Parse(node->ToElement());
+                tileset->Parse(node->ToElement(), file_path);
 
                 // Add the tileset to the list.
                 tilesets.push_back(tileset);

--- a/src/TmxMap.cpp
+++ b/src/TmxMap.cpp
@@ -131,47 +131,21 @@ namespace Tmx
             file_path = "";
         }
 
-        char* fileText;
-        int fileSize;
+        // Create a tiny xml document and use it to parse the text.
+        tinyxml2::XMLDocument doc;
+        doc.LoadFile( fileName.c_str() );
 
-        // Open the file for reading.
-        FILE *file = fopen(fileName.c_str(), "rb");
-
-        // Check if the file could not be opened.
-        if (!file) 
+        // Check for parsing errors.
+        if (doc.Error())
         {
             has_error = true;
-            error_code = TMX_COULDNT_OPEN;
-            error_text = "Could not open the file.";
-            return;
-        }
-    
-        // Find out the file size.  
-        fseek(file, 0, SEEK_END);
-        fileSize = ftell(file);
-        fseek(file, 0, SEEK_SET);
-        
-        // Check if the file size is valid.
-        if (fileSize <= 0)
-        {
-            has_error = true;
-            error_code = TMX_INVALID_FILE_SIZE;
-            error_text = "The size of the file is invalid.";
+            error_code = TMX_PARSING_ERROR;
+            error_text = doc.GetErrorStr1();
             return;
         }
 
-        // Allocate memory for the file and read it into the memory.
-        fileText = new char[fileSize + 1];
-        fileText[fileSize] = 0;
-        fread(fileText, 1, fileSize, file);
-
-        fclose(file);
-
-        // Copy the contents into a C++ string and delete it from memory.
-        std::string text(fileText, fileText+fileSize);
-        delete [] fileText;
-
-        ParseText(text);        
+        tinyxml2::XMLNode *mapNode = doc.FirstChildElement("map");
+        Parse( mapNode );
     }
 
     void Map::ParseText(const string &text) 
@@ -190,6 +164,42 @@ namespace Tmx
         }
 
         tinyxml2::XMLNode *mapNode = doc.FirstChildElement("map");
+        Parse( mapNode );
+    }
+
+    int Map::FindTilesetIndex(int gid) const
+    {
+        // Clean up the flags from the gid (thanks marwes91).
+        gid &= ~(FlippedHorizontallyFlag | FlippedVerticallyFlag | FlippedDiagonallyFlag);
+
+        for (int i = tilesets.size() - 1; i > -1; --i) 
+        {
+            // If the gid beyond the tileset gid return its index.
+            if (gid >= tilesets[i]->GetFirstGid()) 
+            {
+                return i;
+            }
+        }
+        
+        return -1;
+    }
+
+    const Tileset *Map::FindTileset(int gid) const 
+    {
+        for (int i = tilesets.size() - 1; i > -1; --i) 
+        {
+            // If the gid beyond the tileset gid return it.
+            if (gid >= tilesets[i]->GetFirstGid()) 
+            {
+                return tilesets[i];
+            }
+        }
+        
+        return NULL;
+    }
+
+    void Map::Parse(tinyxml2::XMLNode *mapNode)
+    {
         tinyxml2::XMLElement* mapElem = mapNode->ToElement();
 
         // Read the map attributes.
@@ -302,36 +312,5 @@ namespace Tmx
 
             node = node->NextSibling();
         }
-    }
-
-    int Map::FindTilesetIndex(int gid) const
-    {
-        // Clean up the flags from the gid (thanks marwes91).
-        gid &= ~(FlippedHorizontallyFlag | FlippedVerticallyFlag | FlippedDiagonallyFlag);
-
-        for (int i = tilesets.size() - 1; i > -1; --i) 
-        {
-            // If the gid beyond the tileset gid return its index.
-            if (gid >= tilesets[i]->GetFirstGid()) 
-            {
-                return i;
-            }
-        }
-        
-        return -1;
-    }
-
-    const Tileset *Map::FindTileset(int gid) const 
-    {
-        for (int i = tilesets.size() - 1; i > -1; --i) 
-        {
-            // If the gid beyond the tileset gid return it.
-            if (gid >= tilesets[i]->GetFirstGid()) 
-            {
-                return tilesets[i];
-            }
-        }
-        
-        return NULL;
     }
 }

--- a/src/TmxMap.h
+++ b/src/TmxMap.h
@@ -228,5 +228,8 @@ namespace Tmx
         std::string error_text;
 
         Tmx::PropertySet properties;
+
+        // Parse a 'map' node.
+        void Parse(tinyxml2::XMLNode *mapNode);
     };
 }

--- a/src/TmxTileLayer.cpp
+++ b/src/TmxTileLayer.cpp
@@ -172,7 +172,7 @@ namespace Tmx
     void TileLayer::ParseBase64(const std::string &innerText) 
     {
     	std::string testText = innerText;
-    	testText.erase(std::remove_if(testText.begin(), testText.end(), isspace));
+    	Util::Trim( testText );
 
         const std::string &text = Util::DecodeBase64(testText);
 

--- a/src/TmxTileset.cpp
+++ b/src/TmxTileset.cpp
@@ -96,12 +96,39 @@ namespace Tmx
         }
     }
 
-    void Tileset::Parse(const tinyxml2::XMLNode *tilesetNode) 
+    void Tileset::Parse(const tinyxml2::XMLNode *tilesetNode, const std::string& file_path)
     {
         const tinyxml2::XMLElement *tilesetElem = tilesetNode->ToElement();
 
         // Read all the attributes into local variables.
+
+        // The firstgid and source attribute are kept in the TMX map,
+        // since they are map specific.
         first_gid = tilesetElem->IntAttribute("firstgid");
+
+        // If the <tileset> node contains a 'source' tag,
+        // the tileset config should be loaded from an external
+        // TSX (Tile Set XML) file. That file has the same structure
+        // as the <tileset> element in the TMX map.
+        const char* source_name = tilesetElem->Attribute("source");
+
+        tinyxml2::XMLDocument tileset_doc;
+        if ( source_name )
+        {
+            std::string filename = file_path + source_name;
+            tileset_doc.LoadFile( filename.c_str() );
+
+            if ( tileset_doc.ErrorID() != 0)
+            {
+                fprintf(stderr, "failed to load tileset file '%s'\n", filename.c_str());
+                return;
+            }
+
+            // Update node and element references to the new node
+            tilesetNode = tileset_doc.FirstChildElement("tileset");
+            tilesetElem = tilesetNode->ToElement();
+        }
+
         tile_width = tilesetElem->IntAttribute("tilewidth");
         tile_height = tilesetElem->IntAttribute("tileheight");
         margin = tilesetElem->IntAttribute("margin");

--- a/src/TmxTileset.cpp
+++ b/src/TmxTileset.cpp
@@ -115,12 +115,12 @@ namespace Tmx
         tinyxml2::XMLDocument tileset_doc;
         if ( source_name )
         {
-            std::string filename = file_path + source_name;
-            tileset_doc.LoadFile( filename.c_str() );
+            std::string fileName = file_path + source_name;
+            tileset_doc.LoadFile( fileName.c_str() );
 
             if ( tileset_doc.ErrorID() != 0)
             {
-                fprintf(stderr, "failed to load tileset file '%s'\n", filename.c_str());
+                fprintf(stderr, "failed to load tileset file '%s'\n", fileName.c_str());
                 return;
             }
 

--- a/src/TmxTileset.h
+++ b/src/TmxTileset.h
@@ -55,7 +55,7 @@ namespace Tmx
         ~Tileset();
 
         // Parse a tileset element.
-        void Parse(const tinyxml2::XMLNode *tilesetNode);
+        void Parse(const tinyxml2::XMLNode *tilesetNode, const std::string& file_path);
 
         // Returns the global id of the first tile.
         int GetFirstGid() const { return first_gid; }

--- a/src/TmxUtil.cpp
+++ b/src/TmxUtil.cpp
@@ -26,6 +26,7 @@
 // Author: Tamir Atias
 //-----------------------------------------------------------------------------
 #include <stdlib.h>
+#include <algorithm>
 
 #ifdef USE_MINIZ
 #define MINIZ_HEADER_FILE_ONLY
@@ -40,6 +41,29 @@
 #include "base64/base64.h"
 
 namespace Tmx {
+
+    // trim from start
+    static inline std::string &ltrim(std::string &s) {
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+        return s;
+    }
+
+    // trim from end
+    static inline std::string &rtrim(std::string &s) {
+        s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+        return s;
+    }
+
+    // trim from both ends
+    static inline std::string &trim(std::string &s) {
+        return ltrim(rtrim(s));
+    }
+
+    std::string &Util::Trim(std::string &str)
+    {
+        return trim( str );
+    }
+
     std::string Util::DecodeBase64(const std::string &str) 
     {
         return base64_decode(str);

--- a/src/TmxUtil.h
+++ b/src/TmxUtil.h
@@ -34,6 +34,10 @@ namespace Tmx
     class Util 
     {
     public:
+
+        // Trim both leading and trailing whitespace from a string.
+        static std::string &Trim(std::string &str);
+
         // Decode a base-64 encoded string.
         static std::string DecodeBase64(const std::string &str);
 


### PR DESCRIPTION
Hi. I was playing around with your tmx parser (Nice work by the way) while working on a project of mine. After a few segmentation faults I discovered you were lacking tsx support, and went on to implement it. Only now I see you already have a pull request for this feature but for some reason you have not merged it yet (indentation issues?). Anyway, if you feel this one suits you better feel free to merge it.

What I would recommend though is merging the first commit. While I was working on the parser I discovered a bug in a trim function, which was causing the underlying string to repeat some characters in a weird way (Still not sure what it was though). As far as the example tmx went, there was no problem since the decoding stopped at the first appearance of the padding character '=', so the trailing symbols were ignored. But I bumped into cases where there were no padding characters at the end, and the magicaly appended chars were parsed, and then of course everything became inconsistent for decompressing and segfaults occured. I added a Trim function to your Utils module that works.

Cheers, TF