### PR TITLE
Catch up to TMX Format as of Tiled 0.12

### DIFF
--- a/src/TmxMap.cpp
+++ b/src/TmxMap.cpp
@@ -46,11 +46,15 @@ namespace Tmx
         , background_color()
         , version(0.0)
         , orientation(TMX_MO_ORTHOGONAL)
+        , render_order(TMX_RIGHT_DOWN)
+        , stagger_axis(TMX_SA_NONE)
+        , stagger_index(TMX_SI_NONE)
         , width(0)
         , height(0)
         , tile_width(0)
         , tile_height(0)
         , next_object_id(0)
+        , hexside_length(0)
         , layers()
         , tile_layers()
         , object_groups()
@@ -218,19 +222,22 @@ namespace Tmx
         // Read the orientation
         std::string orientationStr = mapElem->Attribute("orientation");
 
-        if (!orientationStr.compare("orthogonal")) 
+        if (!orientationStr.compare("orthogonal"))
         {
             orientation = TMX_MO_ORTHOGONAL;
         } 
-        else if (!orientationStr.compare("isometric")) 
+        else if (!orientationStr.compare("isometric"))
         {
             orientation = TMX_MO_ISOMETRIC;
         }
-        else if (!orientationStr.compare("staggered")) 
+        else if (!orientationStr.compare("staggered"))
         {
             orientation = TMX_MO_STAGGERED;
         }
-        
+        else if (!orientationStr.compare("hexagonal"))
+        {
+            orientation = TMX_MO_HEXAGONAL;
+        }
 
         // Read the render order
         if (mapElem->Attribute("renderorder"))
@@ -254,6 +261,41 @@ namespace Tmx
             }        
         }
 
+        // Read the stagger axis
+        if (mapElem->Attribute("staggeraxis"))
+        {
+            std::string staggerAxisStr = mapElem->Attribute("staggeraxis");
+            if (!staggerAxisStr.compare("x"))
+            {
+                stagger_axis = TMX_SA_X;
+            }
+            else if (!staggerAxisStr.compare("y"))
+            {
+                stagger_axis = TMX_SA_Y;
+            }
+        }
+
+        // Read the stagger index
+        if (mapElem->Attribute("staggerindex"))
+        {
+            std::string staggerIndexStr = mapElem->Attribute("staggerindex");
+            if (!staggerIndexStr.compare("even"))
+            {
+                stagger_index = TMX_SI_EVEN;
+            }
+            else if (!staggerIndexStr.compare("odd"))
+            {
+                stagger_index = TMX_SI_ODD;
+            }
+        }
+
+        // read the hexside length
+        if (mapElem->IntAttribute("hexsidelength"))
+        {
+            hexside_length = mapElem->IntAttribute("hexsidelength");
+        }
+
+        // read all other attributes
         const tinyxml2::XMLNode *node = mapElem->FirstChild();
         while( node )
         {

--- a/src/TmxMap.h
+++ b/src/TmxMap.h
@@ -68,7 +68,10 @@ namespace Tmx
         TMX_MO_ISOMETRIC = 0x02,
 
         // This map is an isometric staggered map.
-        TMX_MO_STAGGERED = 0x03
+        TMX_MO_STAGGERED = 0x03,
+
+        // This map is an hexagonal staggered map.
+        TMX_MO_HEXAGONAL = 0x04
     };
 
     //-------------------------------------------------------------------------
@@ -81,6 +84,26 @@ namespace Tmx
         TMX_RIGHT_UP = 0x02,
         TMX_LEFT_DOWN = 0x03,
         TMX_LEFT_UP= 0x03
+    };
+
+    //-------------------------------------------------------------------------
+    // The stagger axis for the map. (only applies to hexagonal maps)
+    //-------------------------------------------------------------------------
+    enum MapStaggerAxis
+    {
+        TMX_SA_NONE = 0x00,  // if the map is not hexagonal
+        TMX_SA_X = 0x01,
+        TMX_SA_Y = 0x02
+    };
+
+    //-------------------------------------------------------------------------
+    // The stagger index for the map. (applies to hexagonal AND isometric staggered maps)
+    //-------------------------------------------------------------------------
+    enum MapStaggerIndex
+    {
+        TMX_SI_NONE = 0x00,  // if the map is not hexagonal
+        TMX_SI_EVEN = 0x01,
+        TMX_SI_ODD = 0x02
     };
 
     //-------------------------------------------------------------------------
@@ -123,6 +146,12 @@ namespace Tmx
         // Get the render order of the map.
         Tmx::MapRenderOrder GetRenderOrder() const { return render_order; }
 
+        // Get the stagger axis of the map.
+        Tmx::MapStaggerAxis GetStaggerAxis() const { return stagger_axis; }
+
+        // Get the stagger index of the map.
+        Tmx::MapStaggerIndex GetStaggerIndex() const { return stagger_index; }
+
         // Get the width of the map, in tiles.
         int GetWidth() const { return width; }
 
@@ -137,6 +166,9 @@ namespace Tmx
 
         // Get the next object id.
         int GetNextObjectId() const { return next_object_id; }
+
+        // Get the hexside length.
+        int GetHexsideLength() const { return hexside_length; }
 
         // Get the layer at a certain index.
         const Tmx::Layer *GetLayer(int index) const { return layers.at(index); }
@@ -210,12 +242,15 @@ namespace Tmx
         double version;
         Tmx::MapOrientation orientation;
         Tmx::MapRenderOrder render_order;
+        Tmx::MapStaggerAxis stagger_axis;
+        Tmx::MapStaggerIndex stagger_index;
 
         int width;
         int height;
         int tile_width;
         int tile_height;
         int next_object_id;
+        int hexside_length;
 
         std::vector< Tmx::Layer* > layers;
         std::vector< Tmx::TileLayer* > tile_layers;

--- a/src/TmxObject.cpp
+++ b/src/TmxObject.cpp
@@ -80,7 +80,7 @@ namespace Tmx
         
         if (tempName) name = tempName;
         if (tempType) type = tempType;
-        
+
         id = objectElem->IntAttribute("id");
         x = objectElem->IntAttribute("x");
         y = objectElem->IntAttribute("y");

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -36,10 +36,28 @@ int main(int argc, char * argv[])
         printf("error code: %d\n", map->GetErrorCode());
         printf("error text: %s\n", map->GetErrorText().c_str());
 
-        system("PAUSE");
-
         return map->GetErrorCode();
     }
+
+    printf("                                    \n");
+    printf("====================================\n");
+    printf("Map\n");
+    printf("====================================\n");
+
+    printf("Version: %1.1f\n", map->GetVersion());
+    printf("Orientation: %d\n", map->GetOrientation());
+    if (!map->GetBackgroundColor().empty())
+        printf("Background Color (hex): %s\n",
+               map->GetBackgroundColor().c_str());
+    printf("Render Order: %d\n", map->GetRenderOrder());
+    if (map->GetStaggerAxis())
+        printf("Stagger Axis: %d\n", map->GetStaggerAxis());
+    if (map->GetStaggerIndex())
+        printf("Stagger Index: %d\n", map->GetStaggerIndex());
+    printf("Width: %d\n", map->GetWidth());
+    printf("Height: %d\n", map->GetHeight());
+    printf("Tile Width: %d\n", map->GetTileWidth());
+    printf("Tile Height: %d\n", map->GetTileHeight());
 
     // Iterate through the tilesets.
     for (int i = 0; i < map->GetNumTilesets(); ++i)
@@ -60,8 +78,9 @@ int main(int argc, char * argv[])
         printf("Image Width: %d\n", tileset->GetImage()->GetWidth());
         printf("Image Height: %d\n", tileset->GetImage()->GetHeight());
         printf("Image Source: %s\n", tileset->GetImage()->GetSource().c_str());
-        printf("Transparent Color (hex): %s\n",
-                tileset->GetImage()->GetTransparentColor().c_str());
+        if (!tileset->GetImage()->GetTransparentColor().empty())
+            printf("Transparent Color (hex): %s\n",
+                   tileset->GetImage()->GetTransparentColor().c_str());
 
         if (tileset->GetTiles().size() > 0)
         {
@@ -207,8 +226,6 @@ int main(int argc, char * argv[])
     }
 
     delete map;
-
-    system("PAUSE");
 
     return 0;
 }


### PR DESCRIPTION
and report map attributes in the test program.

Now that tmxparser is feature complete, I also suggest to release version 1.12 (1 being the last release of tmxparser, and 0.12 being the current Tiled release) after changing `src/Tmx.h` accordingly:
```
#define TMX_PARSER_VERSION_MAJOR 1
#define TMX_PARSER_VERSION_MINOR 12
```

I should also mention that tmxparser goes down in flames when an `<image>` element does not include the `width` and `height` attributes, which are optional; line 167 of `TmxTileset.cpp` incorrectly assumes that those were parsed even when they were not, causing a crash in line 187 when trying to index into a zero-length vector. Instead of hacking something, I think it's about time to put error checking and assertions all over the place.